### PR TITLE
Show optional parameters to `InstantStartServer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ The collaborative editing plugin works with a server which connects together the
 
 For a localhost or LAN network, you can simple use the built-in server included in the plugin.
 
-* Start it with `:InstantStartServer`
+* Start it with `:InstantStartServer [host] [port]`
 * When done stop it with `:InstantStopServer`
 
-For a more advanced (remote server) overview see [Deploy a server](https://github.com/jbyuki/instant.nvim/wiki/Deploy-a-server)
+The default is to serve localhost only, on port 8080. For a more advanced (remote server) overview see [Deploy a server](https://github.com/jbyuki/instant.nvim/wiki/Deploy-a-server)
 
 ### Client (Neovim)
 


### PR DESCRIPTION
This is a small edit that will hopefully clarify that for LAN usage, you need to set host 0.0.0.0, do ssh port forwarding, or something. You can figure this out from other documentation, but this might reduce friction for people trying out the plugin.