### PR TITLE
add option for working from buffers

### DIFF
--- a/lua/instant.lua
+++ b/lua/instant.lua
@@ -781,6 +781,12 @@ end
 
 local function StartClient(first, appuri, port)
 	local v, username = pcall(function() return vim.api.nvim_get_var("instant_username") end)
+	local work_from_buffer = pcall(function() return vim.api.nvim_get_var("instant_work_from_buffer") end)
+
+	if not work_from_buffer then
+		work_from_buffer = 0
+	end
+
 	if not v then
 		error("Please specify a username in g:instant_username")
 	end
@@ -1419,8 +1425,9 @@ local function StartClient(first, appuri, port)
 									vim.api.nvim_command("doautocmd BufRead " .. vim.api.nvim_buf_get_name(buf))
 								end)
 							end
-
-							vim.api.nvim_buf_set_option(buf, "buftype", "")
+							if not work_from_buffer then
+								vim.api.nvim_buf_set_option(buf, "buftype", "")
+							end
 
 						end
 
@@ -2813,8 +2820,18 @@ local function Join(host, port)
     autocmd_init = true
   end
 
+  local work_from_buffer = pcall(function() return vim.api.nvim_get_var("instant_work_from_buffer") end)
+
+   if not work_from_buffer then
+	work_from_buffer = 0
+   end
 
   local buf = vim.api.nvim_create_buf(true, false)
+
+  if work_from_buffer then
+	vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+  end
+
   vim.api.nvim_win_set_buf(0, buf)
 
 	singlebuf = buf


### PR DESCRIPTION
This is an attempt to address #24. I don't know lua well or how to create a test for this feature but if someone can offer some guidance, I will give it a shot.

How this patch works:

Somewhere in the nvim config, add `let g:instant_work_from_buffer=1`. Once enabled, files opened in the client will have the neovim buftype set to `nofile` and it will not be possibe to save the buffer open in the client. It is presumed the first client sharing the file(s) will have some kind of autosave feature to periodically save the file to the storage device when changes are made. I've been using the `Pocco81/auto-save.nvim` plugin at https://github.com/Pocco81/auto-save.nvim which seems to work well.

Now the client user can just quit the open buffer without worrying about ugly error messages. 